### PR TITLE
fix rabbitmq image to version 3.7

### DIFF
--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:management-alpine
+FROM rabbitmq:3.7-management-alpine
 
 RUN apk add --update jq curl bash
 


### PR DESCRIPTION
Tried to run with `OPTION=1 make run-example`  and got the error below:

```
Step 4/4 : RUN rabbitmq-plugins enable rabbitmq_delayed_message_exchange --offline
 ---> Running in 54176f63c7d4
Enabling plugins on node rabbit@54176f63c7d4:
rabbitmq_delayed_message_exchange
Error:
Failed to enable some plugins: 
    rabbitmq_delayed_message_exchange:
        Plugin doesn't support current server version. Actual broker version: "3.8.9", supported by the plugin: ["3.7.0-3.7.x"]

ERROR: Service 'rabbitmq' failed to build: The command '/bin/sh -c rabbitmq-plugins enable rabbitmq_delayed_message_exchange --offline' returned a non-zero code: 70
make: *** [Makefile:2: run-example] Error 1
```

then I fixed the version on `rabbitmq/Dockerfile` to **3.7** and worked!